### PR TITLE
Fix 'depth_range' and 'z_cam' device mismatch error in 'construct_frus_coor'

### DIFF
--- a/models/projection.py
+++ b/models/projection.py
@@ -39,7 +39,7 @@ class Projection(object):
         y_frus = y.flatten().to(self.device)
         z_frus = z.flatten().to(self.device)
         # project frustum points to vol coord
-        depth_range = torch.linspace(self.near, self.far, self.frustum_size[2])
+        depth_range = torch.linspace(self.near, self.far, self.frustum_size[2]).to(self.device)
         z_cam = depth_range[z_frus].to(self.device)
 
         x_unnorm_pix = x_frus * z_cam


### PR DESCRIPTION
When running `bash scripts/eval_nvs_seg_clevr.sh`, I got the following device mismatch error:
```
Traceback (most recent call last):
  File "test.py", line 32, in <module>
    model.test()           # run inference: forward + compute_visuals
  File "/home/.../uORF/models/base_model.py", line 104, in test
    self.forward()
  File "/home/.../uORF/models/uorf_eval_model.py", line 135, in forward
    frus_nss_coor, z_vals, ray_dir = self.projection.construct_sampling_coor(cam2world, partitioned=True)
  File "/home/.../uORF/models/projection.py", line 63, in construct_sampling_coor
    pixel_coor = self.construct_frus_coor()
  File "/home/.../uORF/models/projection.py", line 43, in construct_frus_coor
    z_cam = depth_range[z_frus].to(self.device)
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```

This PR fixes this by ensuring that `depth_range` is moved to the correct device.