### PR TITLE
Replace '.cuda()' with '.to(self.device)' to enable training/ evaluation on cpu

### DIFF
--- a/models/uorf_eval_model.py
+++ b/models/uorf_eval_model.py
@@ -82,7 +82,7 @@ class uorfEvalModel(BaseModel):
         self.netDecoder = networks.init_net(Decoder(n_freq=opt.n_freq, input_dim=6*opt.n_freq+3+z_dim, z_dim=opt.z_dim, n_layers=opt.n_layer, locality=False,
                                                     locality_ratio=opt.obj_scale/opt.nss_scale, fixed_locality=opt.fixed_locality), gpu_ids=self.gpu_ids, init_type='xavier')
         self.L2_loss = torch.nn.MSELoss()
-        self.LPIPS_loss = lpips.LPIPS().cuda()
+        self.LPIPS_loss = lpips.LPIPS().to(self.device)
 
     def setup(self, opt):
         """Load and print networks; create schedulers

--- a/models/uorf_gan_model.py
+++ b/models/uorf_gan_model.py
@@ -83,7 +83,7 @@ class uorfGanModel(BaseModel):
                             ['unmasked_slot{}_view{}'.format(k, i) for k in range(opt.num_slots) for i in range(n)] + \
                             ['slot{}_attn'.format(k) for k in range(opt.num_slots)]
         self.model_names = ['Encoder', 'SlotAttention', 'Decoder']
-        self.perceptual_net = get_perceptual_net().cuda()
+        self.perceptual_net = get_perceptual_net().to(self.device)
         self.vgg_norm = Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
         render_size = (opt.render_size, opt.render_size)
         frustum_size = [self.opt.frustum_size, self.opt.frustum_size, self.opt.n_samp]

--- a/models/uorf_manip_model.py
+++ b/models/uorf_manip_model.py
@@ -81,7 +81,7 @@ class uorfManipModel(BaseModel):
         self.netDecoder = networks.init_net(Decoder(n_freq=opt.n_freq, input_dim=6*opt.n_freq+3+z_dim, z_dim=opt.z_dim, n_layers=opt.n_layer, locality=False,
                                                     locality_ratio=opt.obj_scale/opt.nss_scale, fixed_locality=opt.fixed_locality), gpu_ids=self.gpu_ids, init_type='xavier')
         self.L2_loss = torch.nn.MSELoss()
-        self.LPIPS_loss = lpips.LPIPS().cuda()
+        self.LPIPS_loss = lpips.LPIPS().to(self.device)
 
     def setup(self, opt):
         """Load and print networks; create schedulers

--- a/models/uorf_nogan_model.py
+++ b/models/uorf_nogan_model.py
@@ -76,7 +76,7 @@ class uorfNoGanModel(BaseModel):
                             ['unmasked_slot{}_view{}'.format(k, i) for k in range(opt.num_slots) for i in range(n)] + \
                             ['slot{}_attn'.format(k) for k in range(opt.num_slots)]
         self.model_names = ['Encoder', 'SlotAttention', 'Decoder']
-        self.perceptual_net = get_perceptual_net().cuda()
+        self.perceptual_net = get_perceptual_net().to(self.device)
         self.vgg_norm = Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
         render_size = (opt.render_size, opt.render_size)
         frustum_size = [self.opt.frustum_size, self.opt.frustum_size, self.opt.n_samp]


### PR DESCRIPTION
Setting the `--gpu_ids -1` fails at the moment due to some `.cuda()` statements. Replacing these with `.to(self.device)` allows training/ evaluation on a CPU. This can be useful for evaluation on machines without a GPU, or for downloading model weights on cluster login nodes without GPU.